### PR TITLE
Add compatibility with DING

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -138,7 +138,8 @@ class Extension {
             return metaWindow.is_on_primary_monitor()
                 && metaWindow.showing_on_its_workspace()
                 && !metaWindow.is_hidden()
-                && metaWindow.get_window_type() !== Meta.WindowType.DESKTOP;
+                && metaWindow.get_window_type() !== Meta.WindowType.DESKTOP
+                && (!Meta.is_wayland_compositor() || !metaWindow.skip_taskbar);
         });
 
         // Check if at least one window is near enough to the panel.


### PR DESCRIPTION
This patch adds compatibility with Desktop Icons NG by taking into account that, under Wayland, the "skip-taskbar" property can be set only under very specific circumstances (that, currently, only DING does fulfill).

Fix https://github.com/lamarios/gnome-shell-extension-transparent-top-bar/issues/9