### PR TITLE
Detect Gtk4-DING window

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -139,7 +139,7 @@ class Extension {
                 && metaWindow.showing_on_its_workspace()
                 && !metaWindow.is_hidden()
                 && metaWindow.get_window_type() !== Meta.WindowType.DESKTOP
-                && (!Meta.is_wayland_compositor() || !metaWindow.skip_taskbar);
+                && !metaWindow.skip_taskbar;
         });
 
         // Check if at least one window is near enough to the panel.


### PR DESCRIPTION
Gtk4-DING desktop window in X11 cannot be detected by the 'DESKTOP' hint, needs to be detected by skip taskbar hint to enable correct transparency on X11 with Gtk4 Ding.